### PR TITLE
Added the possibility for the module to ignore some tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ Intended to make it easier for players to see approximate health of creatures wi
 ## Demo
 ![Demo Animation](demo/HP-Tint-Example.gif)
 
+## Ignore tokens
+The following macro will mark the selected tokens to be ignored by the module:
+```js
+canvas.tokens.controlled.map( token => {
+	token.document._actor.setFlag('hitpoint-tint', 'ignore_token', true);
+	token.document.update({tint: '#ffffff'});
+});
+```
+
+Use the following macro for the tint to work again:
+```js
+canvas.tokens.controlled.map( token => {
+	token.document._actor.unsetFlag('hitpoint-tint', 'ignore_token');
+});
+```
+
 ## Requirements / Limitations:
 - https://github.com/ardittristan/VTTColorSettings is used for settings / color picking.
 - Currently only the 5e module for FoundryVTT is tested / supported. (Enable on other systems at your own risk)

--- a/module.json
+++ b/module.json
@@ -12,6 +12,15 @@
   "download": "https://github.com/Nazacra/hitpoint-tint/archive/v1.1.3.zip",
   "license": "./LICENSE",
   "readme": "./README.md",
+  "packs": [
+    {
+      "name": "Hitpoint Tint Macros",
+      "label": "Hitpoint Tint Macros",
+      "path": "packs/Macros.db",
+      "entity": "Macro",
+      "module": "Hitpoint-tint"
+    }	  
+  ],
   "dependencies": [
     {
       "name": "colorsettings",

--- a/scripts/hitpoint-tint.js
+++ b/scripts/hitpoint-tint.js
@@ -104,7 +104,7 @@ Hooks.on("preUpdateActor", (actor, updateData) => {
     {
       canvas.scene.updateEmbeddedDocuments(actor.parent.documentName,  [{
         tint: newColor,
-        _id: actor.parent.id,.  
+        _id: actor.parent.id,  
       }]);
     }
 

--- a/scripts/hitpoint-tint.js
+++ b/scripts/hitpoint-tint.js
@@ -92,8 +92,9 @@ Hooks.once("ready", () => {
 Hooks.on("preUpdateActor", (actor, updateData) => {
   const newHP = updateData?.data?.attributes?.hp?.value;
   const maxHP = actor?.data?.data?.attributes?.hp?.max;
+  const ignore_token = actor.getFlag('hitpoint-tint', 'ignore_token');
 
-  if (!isNaN(newHP) && !isNaN(newHP)) {
+  if (!isNaN(newHP) && !isNaN(newHP) && !ignore_token) {
     var newColor = getColorFromHPPercent(newHP / maxHP);
 
     console.log(`Hitpoints changed to ${newHP}`);
@@ -103,7 +104,7 @@ Hooks.on("preUpdateActor", (actor, updateData) => {
     {
       canvas.scene.updateEmbeddedDocuments(actor.parent.documentName,  [{
         tint: newColor,
-        _id: actor.parent.id,
+        _id: actor.parent.id,.  
       }]);
     }
 


### PR DESCRIPTION
My players prefer to use health bars for themselves and the tint was adding visual clutter on their tokens.

I also thought it would be a nice option, since some modules may use tokens to represent other things that are not creatures and use HP value to control for some values.
